### PR TITLE
feat: no coverage during watch

### DIFF
--- a/index.js
+++ b/index.js
@@ -334,6 +334,11 @@ const generateRollupConfig = function(options) {
     for (let i = 0; i < process.argv.length; i++) {
       if ((/-w|--watch/).test(process.argv[i])) {
         delete builds.minBrowser;
+        // remove istanbul from test building during watch
+        if (settings.primedPlugins.istanbul && builds.test.plugins.indexOf('istanbul')) {
+          builds.test.plugins.splice(builds.test.plugins.indexOf(settings.primedPlugins.istanbul), 1);
+        }
+
         break;
       }
     }


### PR DESCRIPTION
Do not generate coverage during rollup watch, this way we can prevent having to dig through coverage  information and debug at the same time.