### PR TITLE
feat: no coverage option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Maintenance Status: Stable
   - [`distName`](#distname)
   - [`exportName`](#exportname)
   - [`excludeCoverage`](#excludecoverage)
+  - [`coverage`](#coverage)
   - [`browserslist`](#browserslist)
   - [`checkWatch`](#checkwatch)
   - [`banner`](#banner)
@@ -126,17 +127,14 @@ Defaults are as follows:
 ['test/**', path.join(__dirname, '**'), 'node_modules/**', 'package.json']
 ```
 
-Example:
+### `coverage`
 
-```js
-const config = generateRollupConfig({
-  excludeCoverage(defaults) {
-    defaults.push('fixtures/**');
+> Type: `Boolean`
+> Default: true
 
-    return defaults;
-  }
-});
-```
+
+Whether to include istanbul for the unit test bundle. By default it is included.
+
 
 ### `browserslist`
 

--- a/index.js
+++ b/index.js
@@ -160,8 +160,15 @@ const getSettings = function(options) {
     banner: options.banner || `/*! @name ${pkg.name} @version ${pkg.version} @license ${pkg.license} */`,
 
     // ignore tests, external modules, and package.json
-    excludeCoverage: ['test/**', path.join(__dirname, '**'), 'node_modules/**', 'package.json']
+    excludeCoverage: ['test/**', path.join(__dirname, '**'), 'node_modules/**', 'package.json'],
+
+    // if we should include istanbul by default
+    coverage: typeof options.coverage === 'boolean' ? options.coverage : true
   };
+
+  if (!options.coverage) {
+    defaultPlugins.test.splice(defaultPlugins.test.indexOf('istanbul'), 1);
+  }
 
   const defaultBabel = () => {
     return {


### PR DESCRIPTION
Turn coverage off with a single option. Right now you have to manually remove istanbul from the test plugins array, which is a pain.