### PR TITLE
perf: Faster builds by combining similar builds, and using env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,10 @@ Maintenance Status: Stable
 **Table of Contents**
 
 - [Installation](#installation)
-- [Options](#options)
+- [Environment variables](#environment-variables)
+  - [`TEST_BUNDLE_ONLY`](#test_bundle_only)
+  - [`NO_TEST_BUNDLE`](#no_test_bundle)
+- [Function Options](#function-options)
   - [`input`](#input)
   - [`testInput`](#testinput)
   - [`distName`](#distname)
@@ -72,7 +75,23 @@ export default Object.values(config.builds);
 
 Before you exports you can customize the builds, and you can also pass options (outlined below) to customize the builds.
 
-## Options
+## Environment variables
+These can be passed via rollup's `--environment` or just setting an environment variable
+
+### `TEST_BUNDLE_ONLY`
+> Type: `Boolean`
+> Default: false
+
+Set this to any JavaScript truthy value, to only create a `test` build target. If this option is present `NO_TEST_BUNDLE` will be ignored.
+
+### `NO_TEST_BUNDLE`
+> Type: `Boolean`
+> Default: false
+
+Set this to any JavaScript truthy value, to create all build targets except `test`. This option will be ignored if `TEST_BUNDLE_ONLY` is set.
+
+
+## Function Options
 options that are passed as an object to the `generateRollupConfig` function.
 
 ### `input`

--- a/package-lock.json
+++ b/package-lock.json
@@ -787,9 +787,9 @@
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
     },
     "@types/node": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.0.tgz",
-      "integrity": "sha512-dVeOVH/lhZ2Cki5Emh0aKeXUcWG1+EDTkqyzdgPe0ZjzgvBhzSFlogc6rm8uUd0I+XGK5fcp9DsMv5Wofe0/3w=="
+      "version": "12.6.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.1.tgz",
+      "integrity": "sha512-rp7La3m845mSESCgsJePNL/JQyhkOJA6G4vcwvVgkDAwHhGdq5GCumxmPjEk1MZf+8p5ZQAUE7tqgQRQTXN7uQ=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -5934,14 +5934,15 @@
       }
     },
     "rollup-plugin-terser": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-4.0.4.tgz",
-      "integrity": "sha512-wPANT5XKVJJ8RDUN0+wIr7UPd0lIXBo4UdJ59VmlPCtlFsE20AM+14pe+tk7YunCsWEiuzkDBY3QIkSCjtrPXg==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-5.1.1.tgz",
+      "integrity": "sha512-McIMCDEY8EU6Y839C09UopeRR56wXHGdvKKjlfiZG/GrP6wvZQ62u2ko/Xh1MNH2M9WDL+obAAHySljIZYCuPQ==",
       "requires": {
         "@babel/code-frame": "^7.0.0",
-        "jest-worker": "^24.0.0",
-        "serialize-javascript": "^1.6.1",
-        "terser": "^3.14.1"
+        "jest-worker": "^24.6.0",
+        "rollup-pluginutils": "^2.8.1",
+        "serialize-javascript": "^1.7.0",
+        "terser": "^4.1.0"
       }
     },
     "rollup-pluginutils": {
@@ -6625,13 +6626,13 @@
       }
     },
     "terser": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
-      "integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.1.2.tgz",
+      "integrity": "sha512-jvNoEQSPXJdssFwqPSgWjsOrb+ELoE+ILpHPKXC83tIxOlh2U75F1KuB2luLD/3a6/7K3Vw5pDn+hvu0C4AzSw==",
       "requires": {
-        "commander": "^2.19.0",
+        "commander": "^2.20.0",
         "source-map": "~0.6.1",
-        "source-map-support": "~0.5.10"
+        "source-map-support": "~0.5.12"
       },
       "dependencies": {
         "source-map": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "rollup-plugin-json": "^4.0.0",
     "rollup-plugin-multi-entry": "^2.1.0",
     "rollup-plugin-node-resolve": "^5.2.0",
-    "rollup-plugin-terser": "^4.0.2"
+    "rollup-plugin-terser": "^5.1.1"
   },
   "peerDependencies": {
     "rollup": "^1.12.0"


### PR DESCRIPTION
Noticed a few things that we could do to improve build performance while working on the vhs generator update.

> Note: all numbers are based on VHS build times, which is a bit of an exceptional case.

1. Combine builds `module` and `browser` builds
* terser now supports only running on one file in an output. So having the browser output include both `.min.js` and `.js` saves us around ~3 seconds per build.
* We should have been building modules together all along, this saves us ~2s per build
2. Allow builds to be turned on and off via environment vars
* This allows us to only create the `test` bundle when running tests in ci saving ~15s
* We can also skip the test bundle creation when publishing or running `build` saving ~6s
