### PR TITLE
fix: Make defaults immutable, so watch does not continuously change them

### DIFF
--- a/index.js
+++ b/index.js
@@ -168,14 +168,13 @@ const getSettings = function(options) {
 
   Object.keys(ORDERED_DEFAULTS).forEach(function(key) {
     const defaultValue = ORDERED_DEFAULTS[key](settings);
-    // default to returning the default values.
-    let fn = (v) => v;
 
     if (typeof settings[key] === 'function') {
-      fn = settings[key];
+      settings[key] = settings[key](defaultValue);
+    } else {
+      settings[key] = defaultValue;
     }
 
-    settings[key] = fn(defaultValue);
   });
 
   // validate that plugin strings are valid


### PR DESCRIPTION
Lots of refactoring to make this happen, some of which has been needed but would require a major version, which is about to happen.

Anyway here was the issue:

During `rollup --watch` `defaultGlobals`, `defaultPlugins` etc could be modified. This lead to the list of plugins growing and growing for every rollup rebuild: IE

After four rebuilds, and adding a plugin named `somePlugin` to the top of test plugins:
```
settings.plugins.test = [
     'somePlugin'
     'somePlugin'
     'somePlugin'
     'somePlugin'
     'somePlugin'
      'multiEntry',
      'resolve',
      'json',
      'commonjs',
      'istanbul',
      'babel'
];
```

This happens because `Object.assign` is only a shallow copy and the arrays that it contains are not cloned, but referenced.