### PR TITLE
fix: minifier plugin, babel-config update

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Maintenance Status: Stable
   - [`NO_TEST_BUNDLE`](#no_test_bundle)
 - [Function Options](#function-options)
   - [`input`](#input)
+  - [`minifierPlugin`](#minifierplugin)
   - [`testInput`](#testinput)
   - [`distName`](#distname)
   - [`exportName`](#exportname)
@@ -101,6 +102,13 @@ options that are passed as an object to the `generateRollupConfig` function.
 > Default: `src/plugin.js`
 
 The entry point for your build.
+
+### `minifierPlugin`
+
+> Type: `string`
+> Default: `uglify`
+
+The name of the primed plugin to use when minifying
 
 ### `testInput`
 
@@ -430,3 +438,4 @@ const defaultPrimedPlugins = {
   uglify: uglify({output: {comments: 'some'}}, minify)
 };
 ```
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1066,9 +1066,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.11.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.2.tgz",
-      "integrity": "sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA=="
+      "version": "14.11.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.5.tgz",
+      "integrity": "sha512-jVFzDV6NTbrLMxm4xDSIW/gKnk8rQLF9wAzLWIOg+5nU6ACrIMndeBdXci0FGtqJbP9tQvm6V39eshc96TO2wQ=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -1085,9 +1085,9 @@
       }
     },
     "@videojs/babel-config": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@videojs/babel-config/-/babel-config-0.1.1.tgz",
-      "integrity": "sha512-CyX6Pdt8Ia/cD/rV5RakcHKT4OyeebjJQIzivkHpBYIkvrc9lHwk2FnstTHPpuQstKXv4eO88z8eP1It2VH0Fg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@videojs/babel-config/-/babel-config-0.2.0.tgz",
+      "integrity": "sha512-6OvuB7/UIF+SCx9EcCkZqsoplHqrawUYJt9R0CKXzoLsbfMQaXYfKbWvV2i2+1whOXd2LlyiVMINB3HxZ1quOw==",
       "requires": {
         "@babel/core": "^7.11.6",
         "@babel/plugin-transform-modules-commonjs": "^7.10.4",
@@ -1132,9 +1132,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
-      "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
+      "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
       "dev": true
     },
     "acorn-jsx": {
@@ -1692,9 +1692,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001140",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001140.tgz",
-      "integrity": "sha512-xFtvBtfGrpjTOxTpjP5F2LmN04/ZGfYV8EQzUIC/RmKpdrmzJrjqlJ4ho7sGuAMPko2/Jl08h7x9uObCfBFaAA=="
+      "version": "1.0.30001146",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001146.tgz",
+      "integrity": "sha512-VAy5RHDfTJhpxnDdp2n40GPPLp3KqNrXz1QqFv4J64HvArKs8nuNMOWkB3ICOaBTU/Aj4rYAo/ytdQDDFF/Pug=="
     },
     "caporal": {
       "version": "1.3.0",
@@ -2114,41 +2114,14 @@
       "dev": true
     },
     "conventional-changelog-videojs": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-videojs/-/conventional-changelog-videojs-3.0.0.tgz",
-      "integrity": "sha1-GMJt52U1lZmzXyQ4tYl6gg2wtxg=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-videojs/-/conventional-changelog-videojs-3.0.1.tgz",
+      "integrity": "sha512-SOubwIReSKixpVFc0wFolZO4ELx0rlIPwF1voyWkgGOquzYI9HcDVk8PDGjgQH/6kWIQJu18b9cdGVLWyhCRgg==",
       "dev": true,
       "requires": {
-        "compare-func": "^1.3.1",
+        "compare-func": "^2.0.0",
         "github-url-from-git": "^1.4.0",
         "q": "^1.4.1"
-      },
-      "dependencies": {
-        "compare-func": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.4.tgz",
-          "integrity": "sha512-sq2sWtrqKPkEXAC8tEJA1+BqAH9GbFkGBtUOqrUX57VSfwp8xyktctk+uLoRy5eccTdxzDcVIztlYDpKs3Jv1Q==",
-          "dev": true,
-          "requires": {
-            "array-ify": "^1.0.0",
-            "dot-prop": "^3.0.0"
-          }
-        },
-        "dot-prop": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
-          "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
-          "dev": true,
-          "requires": {
-            "is-obj": "^1.0.0"
-          }
-        },
-        "is-obj": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-          "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-          "dev": true
-        }
       }
     },
     "conventional-changelog-writer": {
@@ -2547,9 +2520,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.576",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.576.tgz",
-      "integrity": "sha512-uSEI0XZ//5ic+0NdOqlxp0liCD44ck20OAGyLMSymIWTEAtHKVJi6JM18acOnRgUgX7Q65QqnI+sNncNvIy8ew=="
+      "version": "1.3.578",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.578.tgz",
+      "integrity": "sha512-z4gU6dA1CbBJsAErW5swTGAaU2TBzc2mPAonJb00zqW1rOraDo2zfBMDRvaz9cVic+0JEZiYbHWPw/fTaZlG2Q=="
     },
     "elegant-spinner": {
       "version": "1.0.1",
@@ -4440,9 +4413,9 @@
       }
     },
     "jest-worker": {
-      "version": "26.3.0",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.3.0.tgz",
-      "integrity": "sha512-Vmpn2F6IASefL+DVBhPzI2J9/GJUsqzomdeN+P+dK8/jKxbh8R3BtFnx3FIta7wYlPU62cpJMJQo4kuOowcMnw==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.5.0.tgz",
+      "integrity": "sha512-kTw66Dn4ZX7WpjZ7T/SUDgRhapFRKWmisVAF0Rv4Fu8SLFD7eLbqpLvbxVqYhSgaWa7I+bW7pHnbyfNsH6stug==",
       "requires": {
         "@types/node": "*",
         "merge-stream": "^2.0.0",
@@ -7051,20 +7024,20 @@
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.17.6",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
-          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+          "version": "1.17.7",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+          "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
           "dev": true,
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
             "has": "^1.0.3",
             "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.0",
-            "is-regex": "^1.1.0",
-            "object-inspect": "^1.7.0",
+            "is-callable": "^1.2.2",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
             "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
+            "object.assign": "^4.1.1",
             "string.prototype.trimend": "^1.0.1",
             "string.prototype.trimstart": "^1.0.1"
           }
@@ -7081,19 +7054,19 @@
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.17.6",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
-          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+          "version": "1.17.7",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+          "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
             "has": "^1.0.3",
             "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.0",
-            "is-regex": "^1.1.0",
-            "object-inspect": "^1.7.0",
+            "is-callable": "^1.2.2",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
             "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
+            "object.assign": "^4.1.1",
             "string.prototype.trimend": "^1.0.1",
             "string.prototype.trimstart": "^1.0.1"
           }
@@ -7110,19 +7083,19 @@
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.17.6",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
-          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+          "version": "1.17.7",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+          "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
             "has": "^1.0.3",
             "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.0",
-            "is-regex": "^1.1.0",
-            "object-inspect": "^1.7.0",
+            "is-callable": "^1.2.2",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
             "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
+            "object.assign": "^4.1.1",
             "string.prototype.trimend": "^1.0.1",
             "string.prototype.trimstart": "^1.0.1"
           }
@@ -7227,9 +7200,9 @@
       "dev": true
     },
     "synchronous-promise": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.13.tgz",
-      "integrity": "sha512-R9N6uDkVsghHePKh1TEqbnLddO2IY25OcsksyFp/qBe7XYd0PVbKEWxhcdMhpLzE1I6skj5l4aEZ3CRxcbArlA==",
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.15.tgz",
+      "integrity": "sha512-k8uzYIkIVwmT+TcglpdN50pS2y1BDcUnBPK9iJeGu0Pl1lOI8pD6wtzgw91Pjpe+RxtTncw32tLxs/R0yNL2Mg==",
       "dev": true
     },
     "table": {
@@ -7345,9 +7318,9 @@
       }
     },
     "terser": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.3.3.tgz",
-      "integrity": "sha512-vRQDIlD+2Pg8YMwVK9kMM3yGylG95EIwzBai1Bw7Ot4OBfn3VP1TZn3EWx4ep2jERN/AmnVaTiGuelZSN7ds/A==",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.3.4.tgz",
+      "integrity": "sha512-dxuB8KQo8Gt6OVOeLg/rxfcxdNZI/V1G6ze1czFUzPeCFWZRtvZMgSzlZZ5OYBZ4HoG607F6pFPNLekJyV+yVw==",
       "requires": {
         "commander": "^2.20.0",
         "source-map": "~0.7.2",
@@ -7493,9 +7466,9 @@
       "dev": true
     },
     "tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.0.tgz",
+      "integrity": "sha512-+Zw5lu0D9tvBMjGP8LpvMb0u2WW2QV3y+D8mO6J+cNzCYIN4sVy43Bf9vl92nqFahutN0I8zHa7cc4vihIshnw==",
       "dev": true
     },
     "tsmlb": {
@@ -7526,9 +7499,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.11.0.tgz",
-      "integrity": "sha512-e1KQFRCpOxnrJsJVqDUCjURq+wXvIn7cK2sRAx9XL3HYLL9aezOP4Pb1+Y3/o693EPk111Yj2Q+IUXxcpHlygQ==",
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.11.1.tgz",
+      "integrity": "sha512-OApPSuJcxcnewwjSGGfWOjx3oix5XpmrK9Z2j0fTRlHGoZ49IU6kExfZTM0++fCArOOCet+vIfWwFHbvWqwp6g==",
       "dev": true,
       "optional": true
     },

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-multi-entry": "^4.0.0",
     "@rollup/plugin-node-resolve": "^9.0.0",
-    "@videojs/babel-config": "^0.1.1",
+    "@videojs/babel-config": "^0.2.0",
     "rollup-plugin-istanbul": "^2.0.1",
     "rollup-plugin-terser": "^7.0.2"
   },


### PR DESCRIPTION
1. Do not minify the non `.min.js` bundle
2. Refer to presets by name, now that that info is exposed.
3. Add an option to configure the minifier plugin name.