### PR TITLE
fix: mark global as global via externalGlobals

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const multiEntry = require('@rollup/plugin-multi-entry');
 const resolve = require('@rollup/plugin-node-resolve').default;
 const {terser} = require('rollup-plugin-terser');
 const istanbul = require('rollup-plugin-istanbul');
+const externalGlobals = require('rollup-plugin-external-globals');
 const path = require('path');
 
 const babelConfig = require('@videojs/babel-config/es.js');
@@ -62,10 +63,7 @@ const MINJS_REGEX = /^.+\.min\.js$/;
 const ORDERED_DEFAULTS = {
   globals: () => ({
     browser: {
-      'video.js': 'videojs',
-      'global': 'window',
-      'global/window': 'window',
-      'global/document': 'document'
+      'video.js': 'videojs'
     },
     module: {
       'video.js': 'videojs'
@@ -92,6 +90,7 @@ const ORDERED_DEFAULTS = {
       'resolve',
       'json',
       'commonjs',
+      'externalGlobals',
       'babel'
     ],
     module: [
@@ -135,6 +134,11 @@ const ORDERED_DEFAULTS = {
     commonjs: commonjs({sourceMap: false}),
     jsonResolve: resolve({extensions: ['.json']}),
     json: json(),
+    externalGlobals: externalGlobals({
+      'global': 'window',
+      'global/window': 'window',
+      'global/document': 'document'
+    }),
     multiEntry: multiEntry({exports: false}),
     resolve: resolve({
       mainFields: ['browser', 'module', 'jsnext:main', 'main'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -6485,6 +6485,33 @@
         "glob": "^7.1.3"
       }
     },
+    "rollup-plugin-external-globals": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-external-globals/-/rollup-plugin-external-globals-0.6.1.tgz",
+      "integrity": "sha512-mlp3KNa5sE4Sp9UUR2rjBrxjG79OyZAh/QC18RHIjM+iYkbBwNXSo8DHRMZWtzJTrH8GxQ+SJvCTN3i14uMXIA==",
+      "requires": {
+        "@rollup/pluginutils": "^4.0.0",
+        "estree-walker": "^2.0.1",
+        "is-reference": "^1.2.1",
+        "magic-string": "^0.25.7"
+      },
+      "dependencies": {
+        "@rollup/pluginutils": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.1.tgz",
+          "integrity": "sha512-clDjivHqWGXi7u+0d2r2sBi4Ie6VLEAzWMIkvJLnDmxoOhBYOTfzGbOQBA32THHm11/LiJbd01tJUpJsbshSWQ==",
+          "requires": {
+            "estree-walker": "^2.0.1",
+            "picomatch": "^2.2.2"
+          }
+        },
+        "estree-walker": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+          "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
+        }
+      }
+    },
     "rollup-plugin-istanbul": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/rollup-plugin-istanbul/-/rollup-plugin-istanbul-2.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@rollup/plugin-multi-entry": "^4.0.0",
     "@rollup/plugin-node-resolve": "^9.0.0",
     "@videojs/babel-config": "^0.2.0",
+    "rollup-plugin-external-globals": "^0.6.1",
     "rollup-plugin-istanbul": "^2.0.1",
     "rollup-plugin-terser": "^7.0.2"
   },


### PR DESCRIPTION
Using the built-in globals feature will try and do interop resolution
for requiring `window` which will break if a user has an element with an
id of `default`. This plugin does not do so and will end up removing the
lines from the browser build altogether.